### PR TITLE
clone instance

### DIFF
--- a/elm-package.json
+++ b/elm-package.json
@@ -7,8 +7,10 @@
         "src/elm"
     ],
     "exposed-modules": [],
+    "native-modules": true,
     "dependencies": {
         "NoRedInk/elm-decode-pipeline": "3.0.0 <= v < 4.0.0",
+        "danyx23/elm-mimetype": "4.0.0 <= v < 5.0.0",
         "debois/elm-mdl": "8.1.0 <= v < 9.0.0",
         "elm-lang/core": "5.1.1 <= v < 6.0.0",
         "elm-lang/html": "2.0.0 <= v < 3.0.0",

--- a/src/elm/FileReader.elm
+++ b/src/elm/FileReader.elm
@@ -1,0 +1,277 @@
+module FileReader
+    exposing
+        ( FileRef
+        , FileContentArrayBuffer
+        , FileContentDataUrl
+        , NativeFile
+        , Error(..)
+        , onFileChange
+        , readAsTextFile
+        , readAsArrayBuffer
+        , readAsDataUrl
+        , prettyPrint
+        , parseSelectedFiles
+        , parseDroppedFiles
+        , filePart
+        , rawBody
+        )
+
+{-| Elm bindings for the main [HTML5 FileReader APIs](https://developer.mozilla.org/en/docs/Web/API/FileReader):
+
+    FileReaderInstance.readAsText();
+    FileReaderInstance.readAsArrayBuffer();
+    FileReaderInstance.readAsDataURL();
+
+The module also provides helper Json Decoders for the files values on
+`<Input type="file">` `change` events, and on `drop` events,
+together with a set of examples.
+
+
+# API functions
+
+@docs readAsTextFile, readAsArrayBuffer, readAsDataUrl
+
+
+# Multi-part support
+
+@docs filePart, rawBody
+
+
+# Helper aliases
+
+@docs NativeFile, FileRef, FileContentArrayBuffer, FileContentDataUrl, Error, prettyPrint
+
+
+# Helper Json Decoders
+
+@docs parseSelectedFiles, parseDroppedFiles
+
+
+# Helpers: Html event handlers
+
+@docs onFileChange
+
+-}
+
+import Html exposing (Attribute)
+import Html.Events exposing (on)
+import Native.FileReader
+import Http exposing (Part, Body)
+import Task exposing (Task, fail)
+import Json.Decode as Json exposing (Decoder, Value)
+import MimeType
+
+
+{-| Helper type for interpreting the Files event value from Input and drag 'n drop.
+The first three elements are useful meta data, while the fourth is the handle
+needed to read the file.
+
+    type alias NativeFile =
+        { name : String
+        , size : Int
+        , mimeType : Maybe MimeType.MimeType
+        , blob : Value
+        }
+
+-}
+type alias NativeFile =
+    { name : String
+    , size : Int
+    , mimeType : Maybe MimeType.MimeType
+    , blob : FileRef
+    }
+
+
+{-| A FileRef (or Blob) is a Elm Json Value.
+-}
+type alias FileRef =
+    Value
+
+
+{-| An ArrayBuffer is a Elm Json Value.
+-}
+type alias FileContentArrayBuffer =
+    Value
+
+
+{-| A DataUrl is an Elm Json Value.
+-}
+type alias FileContentDataUrl =
+    Value
+
+
+{-| FileReader can fail in the following cases:
+
+  - the File reference / blob passed in was not valid
+  - an native error occurs during file reading
+  - readAsTextFile is passed a FileRef that does not have a text format (unrecognised formats are read)
+
+-}
+type Error
+    = NoValidBlob
+    | ReadFail
+    | NotTextFile
+
+
+{-| Takes a "File" or "Blob" JS object as a Json.Value. If the File is a text
+format, returns a task that reads the file as a text file. The Success value is
+represented as a String to Elm.
+
+    readAsTextFile ref
+
+-}
+readAsTextFile : FileRef -> Task Error String
+readAsTextFile fileRef =
+    if isTextFile fileRef then
+        Native.FileReader.readAsTextFile fileRef
+    else
+        fail NotTextFile
+
+
+{-| Takes a "File" or "Blob" JS object as a Json.Value
+and starts a task to read the contents as an ArrayBuffer.
+The ArrayBuffer value returned in the Success case of the Task will
+be represented as a Json.Value to Elm.
+
+    readAsArrayBuffer ref
+
+-}
+readAsArrayBuffer : FileRef -> Task Error FileContentArrayBuffer
+readAsArrayBuffer fileRef =
+    Native.FileReader.readAsArrayBuffer fileRef
+
+
+{-| Takes a "File" or "Blob" JS object as a Json.Value
+and starts a task to read the contents as an DataURL (so it can
+be assigned to the src property of an img e.g.).
+The DataURL value returned in the Success case of the Task will
+be represented as a Json.Value to Elm.
+
+    readAsDataUrl ref
+
+-}
+readAsDataUrl : FileRef -> Task Error FileContentDataUrl
+readAsDataUrl fileRef =
+    Native.FileReader.readAsDataUrl fileRef
+
+
+{-| Creates an Http.Part from a NativeFile, to support uploading of binary files using multipart.
+-}
+filePart : String -> NativeFile -> Part
+filePart name nf =
+    Native.FileReader.filePart name nf.blob
+
+
+{-| Creates an Http.Body from a NativeFile, to support uploading of binary files without using multipart.
+-}
+rawBody : String -> NativeFile -> Body
+rawBody mimeType nf =
+    Native.FileReader.rawBody mimeType nf.blob
+
+
+{-| Pretty print FileReader errors.
+-}
+prettyPrint : Error -> String
+prettyPrint err =
+    case err of
+        ReadFail ->
+            "File reading error"
+
+        NoValidBlob ->
+            "Blob was not valid"
+
+        NotTextFile ->
+            "Not a text file"
+
+
+{-| A 'change' event handler for a `input [ type_ "file" ] []` form element
+-}
+onFileChange : (List NativeFile -> msg) -> Attribute msg
+onFileChange msg =
+    on "change" (Json.map msg parseSelectedFiles)
+
+
+{-| JSON Decoder for change event from an HTML input element with 'type="file"'.
+-}
+parseSelectedFiles : Decoder (List NativeFile)
+parseSelectedFiles =
+    fileParser "target"
+
+
+{-| Parse files selected using an HTML drop event.
+Returns a list of files.
+-}
+parseDroppedFiles : Decoder (List NativeFile)
+parseDroppedFiles =
+    fileParser "dataTransfer"
+
+
+
+-- UN-EXPORTED HELPERS
+
+
+{-| -- Used by readAsText, defaults to True if format not recognised
+-}
+isTextFile : FileRef -> Bool
+isTextFile fileRef =
+    case Json.decodeValue mtypeDecoder fileRef of
+        Ok (Just (MimeType.Text text)) ->
+            True
+
+        Ok Nothing ->
+            True
+
+        _ ->
+            False
+
+
+
+{- DECODERS
+   The Files event has a structure
+
+       { 1 : file1..., 2: file2..., 3 : ... }
+
+   It also inherits other properties that we need to ignore during parsing.
+   fileParser achieves this by using Json.maybe and then filtering out Nothing(s)
+-}
+
+
+fileParser : String -> Decoder (List NativeFile)
+fileParser fieldName =
+    Json.field fieldName <|
+        Json.field "files" <|
+            fileListDecoder nativeFileDecoder
+
+
+{-| Apply a decoder to each file in the FileList, in order.
+-}
+fileListDecoder : Decoder a -> Decoder (List a)
+fileListDecoder decoder =
+    let
+        decodeFileValues indexes =
+            indexes
+                |> List.map (\index -> Json.field (toString index) decoder)
+                |> List.foldr (Json.map2 (::)) (Json.succeed [])
+    in
+        Json.field "length" Json.int
+            |> Json.map (\i -> List.range 0 (i - 1))
+            |> Json.andThen decodeFileValues
+
+
+{-| mime type: parsed as string and then converted to a MimeType
+-}
+mtypeDecoder : Decoder (Maybe MimeType.MimeType)
+mtypeDecoder =
+    Json.map MimeType.parseMimeType (Json.field "type" Json.string)
+
+
+{-| blob: the whole JS File object as a Json.Value so we can pass
+it to a library that reads the content with a native FileReader
+-}
+nativeFileDecoder : Decoder NativeFile
+nativeFileDecoder =
+    Json.map4 NativeFile
+        (Json.field "name" Json.string)
+        (Json.field "size" Json.int)
+        mtypeDecoder
+        Json.value

--- a/src/elm/Native/FileReader.js
+++ b/src/elm/Native/FileReader.js
@@ -1,0 +1,78 @@
+var _thailekha$dynamic_dockerizer_frontend$Native_FileReader = function() {
+
+    var scheduler = _elm_lang$core$Native_Scheduler;
+
+    function useReader(method, fileObjectToRead) {
+        return scheduler.nativeBinding(function(callback){
+
+            /*
+             * Test for existence of FileReader using
+             * if(window.FileReader) { ...
+             * http://caniuse.com/#search=filereader
+             * main gap is IE10 and 11 which do not support readAsBinaryFile
+             * but we do not use this API either as it is deprecated
+             */
+            var reader = new FileReader();
+
+            reader.onload = function(evt) {
+                return callback(scheduler.succeed(evt.target.result));
+            };
+
+            reader.onerror = function() {
+                return callback(scheduler.fail({ctor : 'ReadFail'}));
+            };
+
+            // Error if not passed an objectToRead or if it is not a Blob
+            if (!fileObjectToRead || !(fileObjectToRead instanceof Blob)) {
+                return callback(scheduler.fail({ctor : 'NoValidBlob'}));
+            }
+
+            if (reader[method]) {
+                var result = reader[method](fileObjectToRead);
+                // prevent memory leak by nullifying fileObjectToRead
+                fileObjectToRead = null;
+                return result;
+            } else {
+                return callback(scheduler.fail({ctor : 'ReadFail'}));
+            }
+        });
+    }
+
+    // readAsTextFile : Value -> Task error String
+    var readAsTextFile = function(fileObjectToRead){
+        return useReader("readAsText", fileObjectToRead);
+    };
+
+    // readAsArrayBuffer : Value -> Task error String
+    var readAsArrayBuffer = function(fileObjectToRead){
+        return useReader("readAsArrayBuffer", fileObjectToRead);
+    };
+
+    // readAsDataUrl : Value -> Task error String
+    var readAsDataUrl = function(fileObjectToRead){
+        return useReader("readAsDataURL", fileObjectToRead);
+    };
+
+    var filePart = function(name, blob) {
+        return {
+            _0: name,
+            _1: blob
+        }
+    };
+
+    var rawBody = function (mimeType, blob) {
+        return {
+            ctor: "StringBody",
+            _0: mimeType,
+            _1: blob
+        };
+    };
+
+    return {
+        readAsTextFile : readAsTextFile,
+        readAsArrayBuffer : readAsArrayBuffer,
+        readAsDataUrl: readAsDataUrl,
+        filePart: F2(filePart),
+        rawBody: F2(rawBody)
+    };
+}();

--- a/src/elm/Pages/Home.elm
+++ b/src/elm/Pages/Home.elm
@@ -1,0 +1,41 @@
+module Pages.Home exposing (..)
+
+import RemoteData exposing (WebData)
+import Types.CommonResponses exposing (..)
+
+
+type alias Model =
+    { regionsWebdata : WebData RegionsResponse
+    , awsConfigWebdata : WebData StringResponse
+    }
+
+
+init : Model
+init =
+    { regionsWebdata = RemoteData.NotAsked
+    , awsConfigWebdata = RemoteData.NotAsked
+    }
+
+
+updateRegionswebdata : Model -> WebData RegionsResponse -> Model
+updateRegionswebdata model response =
+    { model
+        | regionsWebdata = response
+    }
+
+
+updateAwsconfigwebdata : Model -> WebData StringResponse -> Model
+updateAwsconfigwebdata model response =
+    { model
+        | awsConfigWebdata = response
+    }
+
+
+tryGetRegions : Model -> List String
+tryGetRegions model =
+    case model.regionsWebdata of
+        RemoteData.Success response ->
+            response.regions
+
+        _ ->
+            []

--- a/src/elm/Pages/Instances.elm
+++ b/src/elm/Pages/Instances.elm
@@ -2,17 +2,20 @@ module Pages.Instances exposing (..)
 
 import RemoteData exposing (WebData)
 import Types.Instances exposing (..)
+import Types.CommonResponses exposing (..)
 import Array
 
 
 type alias Model =
     { instancesWebdata : WebData Instances
+    , cloneWebdata : WebData StringResponse
     }
 
 
 init : Model
 init =
     { instancesWebdata = RemoteData.NotAsked
+    , cloneWebdata = RemoteData.NotAsked
     }
 
 
@@ -20,6 +23,13 @@ updateInstancesWebdata : Model -> WebData Instances -> Model
 updateInstancesWebdata model response =
     { model
         | instancesWebdata = response
+    }
+
+
+updateCloneWebdata : Model -> WebData StringResponse -> Model
+updateCloneWebdata model response =
+    { model
+        | cloneWebdata = response
     }
 
 
@@ -33,13 +43,3 @@ tryGetInstanceFromId model id =
 
         _ ->
             Nothing
-
-
-tryGetInstances : Model -> List Instance
-tryGetInstances model =
-    case model.instancesWebdata of
-        RemoteData.Success response ->
-            response.instances
-
-        _ ->
-            []

--- a/src/elm/Pages/Login.elm
+++ b/src/elm/Pages/Login.elm
@@ -64,3 +64,13 @@ tryGetAccessKeyId model =
 
         Auth.LoggedOut ->
             ""
+
+
+trySecretAccessKey : Model -> String
+trySecretAccessKey model =
+    case model.authenticationState of
+        Auth.LoggedIn creds ->
+            creds.secretAccessKey
+
+        Auth.LoggedOut ->
+            ""

--- a/src/elm/Types/CommonResponses.elm
+++ b/src/elm/Types/CommonResponses.elm
@@ -35,3 +35,14 @@ constructErr msg =
     , statusCode = -1
     , message = msg
     }
+
+
+type alias RegionsResponse =
+    { regions : List String
+    }
+
+
+decodeRegionsResponse : Decoder RegionsResponse
+decodeRegionsResponse =
+    map RegionsResponse
+        (field "regions" (list string))

--- a/src/elm/Types/ProgressKeys.elm
+++ b/src/elm/Types/ProgressKeys.elm
@@ -18,6 +18,16 @@ getClone =
     "get_clone"
 
 
+doClone : String
+doClone =
+    "do_clone"
+
+
+getInstances : String
+getInstances =
+    "get_instances"
+
+
 type alias ProgressKey =
     { key : String
     }

--- a/src/static/index.js
+++ b/src/static/index.js
@@ -13,6 +13,7 @@ function resetLocalStorage() {
   localStorage.removeItem('secretAccessKey');
   localStorage.removeItem('token');
   localStorage.removeItem('ec2Url');
+  localStorage.removeItem('ec2Region');
 }
 
 function getStoredAuthData() {
@@ -22,6 +23,7 @@ function getStoredAuthData() {
   var storedSecretAccessKeyInput = localStorage.getItem('secretAccessKey');
   var storedToken = localStorage.getItem('token');
   var storedEc2Url = localStorage.getItem('ec2Url');
+  var storedEc2Region = localStorage.getItem('ec2Region');
 
   return storedUserNameInput
     && storedAccessKeyIdInput
@@ -32,7 +34,8 @@ function getStoredAuthData() {
       accessKeyId: storedAccessKeyIdInput,
       secretAccessKey: storedSecretAccessKeyInput,
       token: storedToken,
-      ec2Url: storedEc2Url ? storedEc2Url : ""
+      ec2Url: storedEc2Url ? storedEc2Url : "",
+      ec2Region: storedEc2Region ? storedEc2Region : ""
     }) : null;
 }
 
@@ -192,6 +195,13 @@ function setupElmPorts(elmApp) {
       return console.Error("saveEc2Url port some arguments are undefined");
     }
     localStorage.setItem('ec2Url', url);
+  });
+
+  elmApp.ports.saveEc2Region.subscribe(function(region) {
+    if (!is_js.existy(region)) {
+      return console.Error("saveEc2Url port some arguments are undefined");
+    }
+    localStorage.setItem('ec2Region', region);
   });
 
   elmApp.ports.logout.subscribe(function() {


### PR DESCRIPTION
## Motivation
- Clone instance UX

## Result
- Install FileReader as code for uploading keyfile
- Add Home Page to keep track of regions and updating awsconfig
- Able to select instance to be cloned
- Instances Page keeps track of cloning instance
- Submit Keyfile and KeypairName
- Update ProgressKeys to include doClone and getInstances key ids

- After user logging in:
  - Automatically setup workspace
  - Get regions
- After selecting region:
  - Save selected region to localstorage
  - Update aws config on backend
- Clone task:
  - Get a progress key before doing clone
  - Update workspace on the backend with key
  - Reset keys and selected instance after clone
- deleteProgressKey in case req functions do not make requests


## JIRA
https://issues.jboss.org/browse/FH-4848
https://issues.jboss.org/browse/FH-4658
https://issues.jboss.org/browse/FH-4664
https://issues.jboss.org/browse/FH-4665
https://issues.jboss.org/browse/FH-4841