### PR TITLE
checkhost and destroy

### DIFF
--- a/src/elm/Pages/Convert.elm
+++ b/src/elm/Pages/Convert.elm
@@ -9,23 +9,65 @@ import Dict exposing (Dict)
 
 type alias Model =
     { cloneWebdata : WebData ImportedAndCloned
+    , checkhostWebdata : WebData StringResponse
     , processesWebdata : WebData Processes
     , processesConvertWebdata : Dict String (WebData StringResponse)
+    , destroyWebdata : WebData StringResponse
     }
 
 
 init : Model
 init =
     { cloneWebdata = RemoteData.NotAsked
+    , checkhostWebdata = RemoteData.NotAsked
     , processesWebdata = RemoteData.NotAsked
     , processesConvertWebdata = Dict.empty
+    , destroyWebdata = RemoteData.NotAsked
     }
 
 
 updateCloneWebdata : Model -> WebData ImportedAndCloned -> Model
 updateCloneWebdata model response =
+    let
+        nResponse =
+            (case response of
+                RemoteData.Success response ->
+                    { response
+                        | cloned =
+                            Maybe.map
+                                (\clone ->
+                                    { clone
+                                        | publicIp =
+                                            if String.contains "http://" clone.publicIp then
+                                                clone.publicIp
+                                            else
+                                                "http://" ++ clone.publicIp
+                                    }
+                                )
+                                response.cloned
+                    }
+                        |> RemoteData.succeed
+
+                _ ->
+                    response
+            )
+    in
+        { model
+            | cloneWebdata = nResponse
+        }
+
+
+updateCheckhostWebdata : Model -> WebData StringResponse -> Model
+updateCheckhostWebdata model response =
     { model
-        | cloneWebdata = response
+        | checkhostWebdata = response
+    }
+
+
+updateDestroywebdata : Model -> WebData StringResponse -> Model
+updateDestroywebdata model response =
+    { model
+        | destroyWebdata = response
     }
 
 

--- a/src/elm/Types/ProgressKeys.elm
+++ b/src/elm/Types/ProgressKeys.elm
@@ -38,6 +38,11 @@ getProcess =
     "get_process"
 
 
+destroyClone : String
+destroyClone =
+    "destroy_Clone"
+
+
 type alias ProgressKey =
     { key : String
     }

--- a/src/elm/ViewComponents.elm
+++ b/src/elm/ViewComponents.elm
@@ -27,6 +27,7 @@ import Types.ProgressKeys as ProgressKeys
 import Pages.Containers as ContainersPage
 import Pages.Images as ImagesPage
 import Pages.Home as HomePage
+import Pages.Convert as ConvertPage
 import Pages.Router as Router
 import State exposing (Model, Msg)
 import Set exposing (Set)
@@ -509,7 +510,26 @@ convertTableMdl model =
                         , buttonMdl model 2 State.Ec2_URL_Set "Set"
                         ]
                   else
-                    buttonMdl model 0 State.Req_GetProgressKey_Then_GetClone "Find clone"
+                    buttonMdl model 0 State.Req_GetProgressKey_Then_GetClone "Fetch clone"
+                ]
+
+        status =
+            div []
+                [ case model.convertPage.checkhostWebdata of
+                    RemoteData.Success res ->
+                        text res.message
+
+                    _ ->
+                        text "Unkown"
+                , case model.convertPage.destroyWebdata of
+                    RemoteData.Loading ->
+                        progressBar model.master_progressKeys "Destroying" ProgressKeys.destroyClone ""
+
+                    RemoteData.Failure error ->
+                        text (toString error)
+
+                    _ ->
+                        text ""
                 ]
     in
         case model.convertPage.cloneWebdata of
@@ -534,23 +554,34 @@ convertTableMdl model =
 
                         Just clone ->
                             div []
-                                [ textMdl "Found clone"
+                                [ Html.hr [] []
+                                , if clone.instanceId /= "" then
+                                    buttonMdl model -1 State.ConvertPage_Destroy "Destroy"
+                                  else
+                                    text ""
+                                , textMdl "Found clone"
                                 , Table.table []
-                                    [ Table.thead []
-                                        [ Table.tr []
-                                            [ Table.th [] [ text "Tags" ]
-                                            , Table.th [] [ text "Id" ]
-                                            , Table.th [] [ text "Public DNS" ]
-                                            , Table.th [] [ text "Public IP" ]
-                                            ]
-                                        ]
+                                    [ Table.thead [] []
                                     , Table.tbody []
-                                        [ Table.tr
-                                            []
-                                            [ Table.td [] [ text <| toString clone.tags ]
+                                        [ Table.tr []
+                                            [ Table.td [] [ text "Tags" ]
+                                            , Table.td [] [ text <| toString clone.tags ]
+                                            ]
+                                        , Table.tr []
+                                            [ Table.td [] [ text "Id" ]
                                             , Table.td [] [ text <| toString clone.instanceId ]
+                                            ]
+                                        , Table.tr []
+                                            [ Table.td [] [ text "Public DNS" ]
                                             , Table.td [] [ text <| toString clone.dns ]
+                                            ]
+                                        , Table.tr []
+                                            [ Table.td [] [ text "Public IP" ]
                                             , Table.td [] [ text <| toString clone.publicIp ]
+                                            ]
+                                        , Table.tr []
+                                            [ Table.td [] [ text "Status" ]
+                                            , Table.td [] [ status ]
                                             ]
                                         ]
                                     ]


### PR DESCRIPTION
## Motivation
- Query agent for host validity
- Destroy clone instance

## Result
- Convert page keeps track of `checkhost` status and `destroy`
- State keeps track of checkHost and destroy
- progressKey keeps track of destroy clone instance
- converTable showing the cloned instance also shows destroy status
- remoteData.loading is set when getting progressKey response

## Other
- add functions to reset inputs for instancesPage and convertPage
- refactor initModel to return model and cmd
- updateCloneWebdata add "http://" to publicIp if it's not available
- refactor all (model, cmd) in state to model ! [cmd]

## JIRA
https://issues.jboss.org/browse/FH-4748
https://issues.jboss.org/browse/FH-4749
https://issues.jboss.org/browse/FH-4819